### PR TITLE
fix: Correct size of collapse/expand icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         <div class="bg-gray-50 rounded-lg shadow-md border border-gray-200 mb-8 overflow-hidden">
             <div id="guide-header" class="p-6 cursor-pointer flex justify-between items-center">
                 <h2 class="text-2xl font-bold">Guide to Quantitative Risk Analysis</h2>
-                <svg id="guide-toggle-icon" class="w-6 h-6 transition-transform transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                <svg id="guide-toggle-icon" class="w-6 h-6 transition-transform transform" style="width: 1.5rem; height: 1.5rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
             </div>
             <div id="guide-content" class="text-sm">
                  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-6">
@@ -69,7 +69,7 @@
         <div class="bg-white rounded-lg shadow-md mb-8 overflow-hidden">
             <div id="control-library-header" class="p-6 cursor-pointer flex justify-between items-center">
                 <h2 class="text-2xl font-bold">ISO 27001:2022 Control Library</h2>
-                <svg id="control-library-toggle-icon" class="w-6 h-6 transition-transform transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                <svg id="control-library-toggle-icon" class="w-6 h-6 transition-transform transform" style="width: 1.5rem; height: 1.5rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
             </div>
             <div id="control-library-content">
                  <div class="flex space-x-4 mb-4">
@@ -92,7 +92,7 @@
         <div class="bg-white rounded-lg shadow-md mb-8 overflow-hidden">
             <div id="input-form-header" class="p-6 cursor-pointer flex justify-between items-center">
                 <h2 class="text-2xl font-bold">Add New Risk Scenario</h2>
-                <svg id="input-form-toggle-icon" class="w-6 h-6 transition-transform transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                <svg id="input-form-toggle-icon" class="w-6 h-6 transition-transform transform" style="width: 1.5rem; height: 1.5rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
             </div>
             <div id="input-form-content">
                 <div class="p-6">
@@ -239,7 +239,7 @@
         <div class="bg-white rounded-lg shadow-md mb-8 overflow-hidden">
             <div id="risk-chart-header" class="p-6 cursor-pointer flex justify-between items-center">
                 <h2 class="text-2xl font-bold">Risk Portfolio Overview (ALE)</h2>
-                <svg id="risk-chart-toggle-icon" class="w-6 h-6 transition-transform transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                <svg id="risk-chart-toggle-icon" class="w-6 h-6 transition-transform transform" style="width: 1.5rem; height: 1.5rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
             </div>
             <div id="risk-chart-content">
                 <div class="p-6">
@@ -257,7 +257,7 @@
         <div class="bg-white rounded-lg shadow-md mb-8 overflow-hidden">
             <div id="risk-table-header" class="p-6 cursor-pointer flex justify-between items-center">
                 <h2 class="text-2xl font-bold">Risk Scenarios</h2>
-                <svg id="risk-table-toggle-icon" class="w-6 h-6 transition-transform transform" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                <svg id="risk-table-toggle-icon" class="w-6 h-6 transition-transform transform" style="width: 1.5rem; height: 1.5rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
             </div>
             <div id="risk-table-content">
                 <div class="overflow-x-auto">


### PR DESCRIPTION
This commit fixes a visual bug where the SVG icons for collapsing and expanding sections were rendering at a very large size.

The fix involves adding inline styles (`width: 1.5rem; height: 1.5rem;`) to each of the five SVG toggle icons in `index.html`. This ensures they are displayed at the intended size, consistent with the `w-6` and `h-6` Tailwind CSS classes.